### PR TITLE
Ensure transactional seat locking to prevent double-booking

### DIFF
--- a/internal/router/customer_routes.go
+++ b/internal/router/customer_routes.go
@@ -1,9 +1,9 @@
 package router
 
 import (
-    "github.com/iliyamo/cinema-seat-reservation/internal/handler"
-    "github.com/iliyamo/cinema-seat-reservation/internal/middleware"
-    "github.com/labstack/echo/v4"
+	"github.com/iliyamo/cinema-seat-reservation/internal/handler"
+	"github.com/iliyamo/cinema-seat-reservation/internal/middleware"
+	"github.com/labstack/echo/v4"
 )
 
 // RegisterCustomer registers customer-scoped endpoints under /v1.  All routes
@@ -11,24 +11,24 @@ import (
 // status for shows, place holds on seats, release holds, confirm
 // reservations and view their own reservations.
 func RegisterCustomer(e *echo.Echo, h *handler.CustomerHandler, jwtSecret string) {
-    g := e.Group(
-        "/v1",
-        middleware.JWTAuth(jwtSecret),
-        middleware.RequireRole("CUSTOMER"),
-    )
-    // Note: GET /v1/shows/:id/seats, GET /v1/halls/:id/seats/layout and
-    // GET /v1/halls/:id/seats are registered on the public router so that
-    // guests can view seat availability and hall seat lists.  Customer-specific
-    // endpoints begin here.
-    g.POST("/shows/:id/hold", h.HoldSeats)
-    g.DELETE("/shows/:id/hold", h.ReleaseHolds)
-    g.POST("/shows/:id/confirm", h.ConfirmSeats)
-    g.GET("/my-reservations", h.ListReservations)
+	g := e.Group(
+		"/v1",
+		middleware.JWTAuth(jwtSecret),
+		middleware.RequireRole("CUSTOMER"),
+	)
+	// Note: GET /v1/shows/:id/seats, GET /v1/halls/:id/seats/layout and
+	// GET /v1/halls/:id/seats are registered on the public router so that
+	// guests can view seat availability and hall seat lists.  Customer-specific
+	// endpoints begin here.
+	g.POST("/shows/:id/hold", h.HoldSeats)
+	g.DELETE("/shows/:id/hold", h.ReleaseHolds)
+	g.POST("/shows/:id/confirm", h.ConfirmSeats)
+	g.GET("/my-reservations", h.ListReservations)
 
-    // Reservation detail and deletion endpoints for customers.  These
-    // endpoints allow a customer to view or cancel a reservation
-    // belonging to themselves.  They are protected by the CUSTOMER
-    // role and validated within the handler.
-    g.GET("/reservations/:id", h.GetReservation)
-    g.DELETE("/reservations/:id", h.DeleteReservation)
+	// Reservation detail and deletion endpoints for customers.  These
+	// endpoints allow a customer to view or cancel a reservation
+	// belonging to themselves.  They are protected by the CUSTOMER
+	// role and validated within the handler.
+	g.GET("/reservations/:id", h.GetReservation)
+	g.DELETE("/reservations/:id", h.DeleteReservation)
 }


### PR DESCRIPTION
### This PR introduces critical updates to the booking flow to ensure data consistency and eliminate race conditions in seat holding and reservation operations. All relevant endpoints now use database-level row locks to guarantee correctness in concurrent scenarios.

### Key Changes:

- **Seat Hold Flow (`POST /v1/shows/:id/hold`)**
  - Acquires row-level locks on `show_seats` using `SELECT ... FOR UPDATE`
  - Filters out seats that are already HELD, RESERVED, or actively held by others
  - Prevents concurrent seat grabs by committing the hold only after all checks pass

- **Reservation Flow (`POST /v1/shows/:id/reserve`)**
  - Verifies held seats using row-level locking
  - Confirms active `seat_holds` belong to the current user and have not expired
  - Converts HELD seats into a reservation with full transaction safety

- **Hold Expiry Management**
  - Expired `seat_holds` are removed before any operation
  - Associated `show_seats` are reverted to FREE status as needed

- **Transaction Handling**
  - Every operation is executed inside a proper transaction
  - Rollbacks are triggered on any failure to maintain data integrity

- **Developer Notes**
  - Added extensive inline comments to explain the use of locks and transactions
  - Error handling for unavailable or invalid seat states is now deterministic and safe

### Result:
- Eliminates race conditions that previously allowed simultaneous seat reservations
- Ensures that only one customer can hold or confirm a seat at a time
- Booking system is now safe for high concurrency environments

All changes tested using Postman/HTTPie against live DB scenarios.